### PR TITLE
append ha-addons to ghcr.io address

### DIFF
--- a/.github/workflows/ha-addon-ci.yaml
+++ b/.github/workflows/ha-addon-ci.yaml
@@ -166,10 +166,7 @@ jobs:
             echo "::set-output name=platform::linux/386"
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
             echo "::set-output name=platform::linux/arm/v6"
-          elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
-            echo "::set-output name=platform::linux/arm/v7"
-          elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "::set-output name=platform::linux/arm64/v8"
+          elif [[ "${{ matrix.architecture }}"line-lengthlinux/arm64/v8"
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1
@@ -188,9 +185,10 @@ jobs:
           push: false
           context: ${{ needs.information.outputs.target }}
           file: ${{ needs.information.outputs.target }}/Dockerfile
+          # yamllint disable rule:line-length
           cache-from: |
             type=local,src=/tmp/.docker-cache
-            ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:edge
+            ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:edge
           cache-to: type=local,mode=max,dest=/tmp/.docker-cache-new
           platforms: ${{ steps.flags.outputs.platform }}
           build-args: |

--- a/.github/workflows/ha-addon-deploy.yaml
+++ b/.github/workflows/ha-addon-deploy.yaml
@@ -142,14 +142,15 @@ jobs:
           load: true
           # yamllint disable rule:line-length
           tags: |
-            ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.environment }}
-            ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}
+            ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.environment }}
+            ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}
           # yamllint enable rule:line-length
           context: ${{ needs.information.outputs.target }}
           file: ${{ needs.information.outputs.target }}/Dockerfile
+          # yamllint disable rule:line-length
           cache-from: |
             type=local,src=/tmp/.docker-cache
-            ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:edge
+            ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:edge
           cache-to: type=local,mode=max,dest=/tmp/.docker-cache-new
           platforms: ${{ steps.flags.outputs.platform }}
           build-args: |
@@ -168,12 +169,12 @@ jobs:
           if ! cas authenticate \
             --signerID "${{ needs.information.outputs.signer }}" \
             --silent \
-            "docker://ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}";
+            "docker://ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}";
           then
             cas notarize \
               --api-key="${{ secrets.CAS_API_KEY }}" \
               --name "${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}" \
-              "docker://ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}"
+              "docker://ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}"
           fi
       # This ugly bit is necessary, or our cache will grow forever...
       # Well until we hit GitHub's limit of 5GB :)
@@ -187,7 +188,7 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           docker push \
-            "ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.environment }}"
+            "ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.environment }}"
           docker push \
-            "ghcr.io/${{ inputs.ghcr_repo }}/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}"
+            "ghcr.io/${{ inputs.ghcr_repo }}/ha-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:${{ needs.information.outputs.version }}"
 


### PR DESCRIPTION
# Proposed Changes

Append /ha-addons/ to remote docker image address for 
- ha-addon-ci
- ha-addon-deploy

 since these actions are exclusive for ha addons by appending this string the docker images will not collide with other projects.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
