### PR TITLE
Rework set-outputs

### DIFF
--- a/.github/workflows/ha-addon-base-ci.yaml
+++ b/.github/workflows/ha-addon-base-ci.yaml
@@ -139,20 +139,20 @@ jobs:
       - name: ℹ️ Compose build flags
         id: flags
         run: |
-          echo "::set-output name=date::$(date +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "date::$(date +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
           from=$(yq --no-colors eval ".build_from.${{ matrix.architecture }}" "${{ needs.information.outputs.build }}")
-          echo "::set-output name=from::${from}"
+          echo "from::${from}" >> $GITHUB_OUTPUT
 
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
-            echo "::set-output name=platform::linux/amd64"
+            echo "platform::linux/amd64" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
-            echo "::set-output name=platform::linux/386"
+            echo "platform::linux/386" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
-            echo "::set-output name=platform::linux/arm/v6"
+            echo "platform::linux/arm/v6" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
-            echo "::set-output name=platform::linux/arm/v7"
+            echo "platform::linux/arm/v7" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "::set-output name=platform::linux/arm64/v8"
+            echo "platform::linux/arm64/v8" >> $GITHUB_OUTPUT
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1

--- a/.github/workflows/ha-addon-ci.yaml
+++ b/.github/workflows/ha-addon-ci.yaml
@@ -39,7 +39,7 @@ jobs:
           if [[ ! -z "${{ inputs.slug }}" ]]; then
             slug="${{ inputs.slug }}"
           fi
-          echo "::set-output name=slug::$slug"
+          echo "slug::$slug" >> $GITHUB_OUTPUT
 
   lint-addon:
     name: Lint Add-on
@@ -156,20 +156,20 @@ jobs:
       - name: ℹ️ Compose build flags
         id: flags
         run: |
-          echo "::set-output name=date::$(date +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "date::$(date +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
           from=$(yq --no-colors eval ".build_from.${{ matrix.architecture }}" "${{ needs.information.outputs.build }}")
-          echo "::set-output name=from::${from}"
+          echo "from::${from}" >> $GITHUB_OUTPUT
 
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
-            echo "::set-output name=platform::linux/amd64"
+            echo "platform::linux/amd64" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
-            echo "::set-output name=platform::linux/386"
+            echo "platform::linux/386" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
-            echo "::set-output name=platform::linux/arm/v6"
+            echo "platform::linux/arm/v6" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
-            echo "::set-output name=platform::linux/arm/v7"
+            echo "platform::linux/arm/v7" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "::set-output name=platform::linux/arm64/v8"
+            echo "platform::linux/arm64/v8" >> $GITHUB_OUTPUT
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1

--- a/.github/workflows/ha-addon-deploy.yaml
+++ b/.github/workflows/ha-addon-deploy.yaml
@@ -53,7 +53,7 @@ jobs:
           if [[ ! -z "${{ inputs.slug }}" ]]; then
             slug="${{ inputs.slug }}"
           fi
-          echo "::set-output name=slug::$slug"
+          echo "slug::$slug" >> $GITHUB_OUTPUT
       - name: ℹ️ Gather version and environment
         id: release
         run: |
@@ -70,8 +70,8 @@ jobs:
             fi
           fi
 
-          echo "::set-output name=environment::${environment}"
-          echo "::set-output name=version::${version}"
+          echo "environment::${environment}" >> $GITHUB_OUTPUT
+          echo "version::${version}" >> $GITHUB_OUTPUT
 
   deploy:
     name: 👷 Build & Deploy ${{ matrix.architecture }}
@@ -104,20 +104,20 @@ jobs:
       - name: ℹ️ Compose build flags
         id: flags
         run: |
-          echo "::set-output name=date::$(date +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "date::$(date +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
           from=$(yq --no-colors eval ".build_from.${{ matrix.architecture }}" "${{ needs.information.outputs.build }}")
-          echo "::set-output name=from::${from}"
+          echo "from::${from}" >> $GITHUB_OUTPUT
 
           if [[ "${{ matrix.architecture}}" = "amd64" ]]; then
-            echo "::set-output name=platform::linux/amd64"
+            echo "platform::linux/amd64" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "i386" ]]; then
-            echo "::set-output name=platform::linux/386"
+            echo "platform::linux/386" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armhf" ]]; then
-            echo "::set-output name=platform::linux/arm/v6"
+            echo "platform::linux/arm/v6" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "armv7" ]]; then
-            echo "::set-output name=platform::linux/arm/v7"
+            echo "platform::linux/arm/v7" >> $GITHUB_OUTPUT
           elif [[ "${{ matrix.architecture }}" = "aarch64" ]]; then
-            echo "::set-output name=platform::linux/arm64/v8"
+            echo "platform::linux/arm64/v8" >> $GITHUB_OUTPUT
           else
             echo "::error ::Could not determine platform for architecture ${{ matrix.architecture }}"
             exit 1


### PR DESCRIPTION
# Proposed Changes

replace the `set-output` command with `>> $GITHUB_OUTPUT` as suggested in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Related Issues

Apply solution from warning message:

`Warning: The set-output command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/`


> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
