### PR TITLE
Update prettier

### DIFF
--- a/.github/workflows/ha-addon-base-ci.yaml
+++ b/.github/workflows/ha-addon-base-ci.yaml
@@ -100,7 +100,7 @@ jobs:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v3
       - name: 🚀 Run Prettier
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write **/*.{json,js,md,yaml}
         env:

--- a/.github/workflows/ha-addon-ci.yaml
+++ b/.github/workflows/ha-addon-ci.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@v3
       - name: 🚀 Run Prettier
-        uses: creyD/prettier_action@v4.2
+        uses: creyD/prettier_action@v4.3
         with:
           prettier_options: --write **/*.{json,js,md,yaml}
         env:


### PR DESCRIPTION
# Proposed Changes

update prettied to v4.3

## Related Issues

Actions were failing randomly on prettier stage with message:

`/home/runner/work/_actions/creyD/prettier_action/v4.2/entrypoint.sh: line 74: prettier: command not found`

Updating to v4.3 apparently solves this

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
