### PR TITLE
Limit prettier actions

### DIFF
--- a/.github/workflows/ha-addon-ci.yaml
+++ b/.github/workflows/ha-addon-ci.yaml
@@ -117,7 +117,9 @@ jobs:
       - name: 🚀 Run Prettier
         uses: creyD/prettier_action@v4.3
         with:
-          prettier_options: --write **/*.{json,js,md,yaml}
+          only_changed: True
+          dry: True
+          #prettier_options: --write **/*.{json,js,md,yaml}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# Proposed Changes

Set prettier action to only dry-run due to lack of permissions

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
