### PR TITLE
Add action to publish homeassistant addon

### DIFF
--- a/.github/workflows/ha-addon-publish.yaml
+++ b/.github/workflows/ha-addon-publish.yaml
@@ -1,0 +1,26 @@
+---
+name: Publish AddOn
+
+on:
+  workflow_call:
+    inputs:
+      add_on:
+        description: add-on to be published
+        required: true
+        type: string
+    secrets:
+      DISPATCH_TOKEN:
+        required: true
+
+jobs:      
+  publish:
+    name: 📢 Publish Add-on
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🚀 Dispatch Repository Updater update signal
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISPATCH_TOKEN }}
+          repository: coostax/ha-addons
+          event-type: update
+          client-payload: '{"addon": "${{ inputs.add_on }}"}'

--- a/.github/workflows/ha-addon-publish.yaml
+++ b/.github/workflows/ha-addon-publish.yaml
@@ -1,6 +1,7 @@
 ---
 name: Publish AddOn
 
+# yamllint disable-line rule:truthy
 on:
   workflow_call:
     inputs:
@@ -12,7 +13,7 @@ on:
       DISPATCH_TOKEN:
         required: true
 
-jobs:      
+jobs:
   publish:
     name: 📢 Publish Add-on
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Proposed Changes

Add generic action to publish a new version of a home-assistant add-on.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
